### PR TITLE
This fixes local echo by closing all open output tags before sending user commands to the server.

### DIFF
--- a/CLA-signed/CLA.NOAHGIBBS.A3FDB54C32A502FB631C4CCF0A40508858FF18B3.asc
+++ b/CLA-signed/CLA.NOAHGIBBS.A3FDB54C32A502FB631C4CCF0A40508858FF18B3.asc
@@ -1,0 +1,74 @@
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA256
+
+# Contributor License Agreement
+
+Version 1.0
+
+Name: Noah Gibbs
+
+E-Mail: the.codefolio.guy@gmail.com
+
+Legal Jurisdiction: Wyoming, United States of America
+
+Project: https://github.com/ChatTheatre/orchil
+
+Date: Sep 11, 2020
+
+## Purpose
+
+This agreement gives Dyvers Hands Productions LLC Series 5 ("_**Dyvers Hands**_") the permission it needs in order to accept my contributions into its open software project and to manage the intellectual property in that project over time.
+
+## License
+
+I hereby license Dyvers Hands to:
+
+1.  do anything with my contributions that would otherwise infringe my copyright in them
+
+2.  do anything with my contributions that would otherwise infringe patents that I can or become able to license
+
+3.  sublicense these rights to others on any terms they like
+
+## Reliability
+
+I understand that Dyvers Hands will rely on this license.  I may not revoke this license.
+
+## Awareness
+
+I promise that I am familiar with legal rules, like ["work made for hire" rules](http://worksmadeforhire.com), that can give employers and clients ownership of intellectual property in work that I do.  I am also aware that legal agreements I might sign, like confidential information and invention assignment agreements, will usually give ownership of intellectual property in my work to employers, clients, and companies that I found.  If someone else owns intellectual property in my work, I need their permission to license it.
+
+## Copyright Guarantee
+
+I promise not to offer contributions to the project that contain copyrighted work that I do not have legally binding permission to contribute under these terms.  When I offer a contribution with permission, I promise to document in the contribution who owns copyright in what work, and how they gave permission to contribute it.  If I later become aware that one of my contributions may have copyrighted work of others that I did not have permission to contribute, I will notify Blockchain Commons, in confidence, immediately.
+
+## Patent Guarantee
+
+I promise not to offer contributions to the project that I know infringe patents of others that I do not have permission to contribute under these terms.
+
+## Open Source Guarantee
+
+I promise not to offer contributions that contain or depend on the work of others, unless that work is available under a license that [Blue Oak Council rates bronze or better](https://blueoakconcil.org/list), such as the MIT License, two- or three-clause BSD License, the Apache License Version 2.0, or the Blue Oak Model License 1.0.0.  When I offer a contribution containing or depending on others' work, I promise to document in the contribution who licenses that work, along with copies of their license terms.
+
+## Disclaimers
+
+***As far as the law allows, my contributions come as is, without any warranty or condition.  Other than under [Copyright Guarantee](#copyright-guarantee), [Patent Guarantee](#patent-guarantee), or [Open Source Guarantee](#open-source-guarantee), I will not be liable to anyone for any damages related to my contributions or this contributor license agreement, under any kind of legal claim.***
+
+- ---
+
+To sign this Contributor License Agreement, fill in `$name`, `$email`, and `$date` above. Then sign using GPG using the following command `gpg --armor --clearsign --output ./CLA-signed/CLA.YOURGITHUBNAME.YOURGPGFINGERPRINT.asc CLA.md`, then either submit your signed Contributor License Agreement to this repo as a GPG signed Pull Request or email it to [ChristopherA@DyversHands.com](mailto:ChristopherA@DyversHands.com).
+-----BEGIN PGP SIGNATURE-----
+
+iQIzBAEBCAAdFiEEo/21TDKlAvtjHEzPCkBQiFj/GLMFAl9bwWkACgkQCkBQiFj/
+GLOMGBAA1zuEtR2WtLzuxEdK91aNUPy77sKA1UAZ9kUoPGx9ce5Wo0rB/ViutVPT
+jYXyjtZnCmDzqj6t+YdoRDvf0T21NsBJds+slt3nI4TKpdWAgSBx17o/9PG3koqK
+pZqaU2WyLBMsHk24vVycjoaFOYteF3MwQpG0FT3mpKimtmWrD6/iKJbSEn+RdTSP
+i1C9fD0n3vZh5SR8c372vWC+mL2QMKJivAZS4rqLZ44CxouNdDQtSb6NXFXvn/T8
+sMeHyAp6JnoBsq7niBpqL0K1m6H9wQ56VHftD1/BeIndDNZtf6q1p7TMDMuHmkvF
++T0JD55VspD6Q8SZDAJLlLl8ZYPvtjvu50ZlIbc1CvSgLazTlzTzvhmjpJ7Etj6g
+Gv1oeoi4vtuOBg47zdOzWipBHXeSqmsw3kq+AUpMfkVI19CWgCnWYabLzwBcRJDy
+6I/QHKHaFI0jAh2UIEze9SJtCJmatAVeUcnzaCNUNjndKvTLPXC/Ze0E4Aa9TKik
+De+ZLWPJ5lYujZGy5VIgvh3EIn05a2ROFHrhSa5Z4hc5z5o5rm/zViW/ofQtw8vA
+KBWRXYAvkf2hOLN32jCE+E3l9HJS0zr+weijfuxtOeU4PwrK119DSRXwjs+w44Wp
+S4ngfsKdsiD9uNVW7Z51JcYViBW5UJ1kodp65fts9vFs1/JglzU=
+=b+Yw
+-----END PGP SIGNATURE-----

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,55 @@
+# Contributor License Agreement
+
+Version 1.0
+
+Name: `$name`
+
+E-Mail: `$email`
+
+Legal Jurisdiction: Wyoming, United States of America
+
+Project: https://github.com/ChatTheatre/orchil
+
+Date: `$date`
+
+## Purpose
+
+This agreement gives Dyvers Hands Productions LLC Series 5 ("_**Dyvers Hands**_") the permission it needs in order to accept my contributions into its open software project and to manage the intellectual property in that project over time.
+
+## License
+
+I hereby license Dyvers Hands to:
+
+1.  do anything with my contributions that would otherwise infringe my copyright in them
+
+2.  do anything with my contributions that would otherwise infringe patents that I can or become able to license
+
+3.  sublicense these rights to others on any terms they like
+
+## Reliability
+
+I understand that Dyvers Hands will rely on this license.  I may not revoke this license.
+
+## Awareness
+
+I promise that I am familiar with legal rules, like ["work made for hire" rules](http://worksmadeforhire.com), that can give employers and clients ownership of intellectual property in work that I do.  I am also aware that legal agreements I might sign, like confidential information and invention assignment agreements, will usually give ownership of intellectual property in my work to employers, clients, and companies that I found.  If someone else owns intellectual property in my work, I need their permission to license it.
+
+## Copyright Guarantee
+
+I promise not to offer contributions to the project that contain copyrighted work that I do not have legally binding permission to contribute under these terms.  When I offer a contribution with permission, I promise to document in the contribution who owns copyright in what work, and how they gave permission to contribute it.  If I later become aware that one of my contributions may have copyrighted work of others that I did not have permission to contribute, I will notify Blockchain Commons, in confidence, immediately.
+
+## Patent Guarantee
+
+I promise not to offer contributions to the project that I know infringe patents of others that I do not have permission to contribute under these terms.
+
+## Open Source Guarantee
+
+I promise not to offer contributions that contain or depend on the work of others, unless that work is available under a license that [Blue Oak Council rates bronze or better](https://blueoakconcil.org/list), such as the MIT License, two- or three-clause BSD License, the Apache License Version 2.0, or the Blue Oak Model License 1.0.0.  When I offer a contribution containing or depending on others' work, I promise to document in the contribution who licenses that work, along with copies of their license terms.
+
+## Disclaimers
+
+***As far as the law allows, my contributions come as is, without any warranty or condition.  Other than under [Copyright Guarantee](#copyright-guarantee), [Patent Guarantee](#patent-guarantee), or [Open Source Guarantee](#open-source-guarantee), I will not be liable to anyone for any damages related to my contributions or this contributor license agreement, under any kind of legal claim.***
+
+---
+
+To sign this Contributor License Agreement, fill in `$name`, `$email`, and `$date` above. Then sign using GPG using the following command `gpg --armor --clearsign --output ./CLA-signed/CLA.YOURGITHUBNAME.YOURGPGFINGERPRINT.asc CLA.md`, then either submit your signed Contributor License Agreement to this repo as a GPG signed Pull Request or email it to [ChristopherA@DyversHands.com](mailto:ChristopherA@DyversHands.com).

--- a/orchil.js
+++ b/orchil.js
@@ -945,6 +945,7 @@ var c = {};
 		function doSend(message, noecho) {
 			if (!conn.connected) return;
 			var debug = false;
+			closeAllSubElements();
 			if (prefs.local_echo === "off") noecho = true;
 			if(!noecho) {
 				if (c.promptStr) {
@@ -1496,6 +1497,10 @@ var c = {};
 		//} else {
 		//	currentSubElements = [];
 		//}
+	}
+	function closeAllSubElements() {
+		currentSubElements.splice(0);
+		plog("Removed all subelements.", currentSubElements);
 	}
 
 	function addToCurrentElement(text) {


### PR DESCRIPTION
Fixes "https://github.com/ChatTheatre/orchil/issues/5".

There's probably more to be fixed - I'm still not sure how the "> " prompt is printed, and there may be more bad interactions. But this fixes obvious problems with reversed printing of local_echo text, and dealing with printScreened() output like "The client preference 'local_echo' is already set to 'on'."

So this is a useful improvement, but I think there are probably still errors in how currentSubElements and prompt interact.

If you have an account on The Gables, you can use this in production by going to "http://client.gables.chattheatre.com/gables/gables2.htm". Or it's easier to log in, then go to the new URL (add the number 2) and shift-reload.