### PR TITLE
Use SkotOS server-side themes

### DIFF
--- a/orchil.js
+++ b/orchil.js
@@ -1664,7 +1664,7 @@ var c = {};
 			// Various unhandled attributes exist and we're ignoring them.
 		}
 
-		let cssText = "#output {" + outputAttributes + "}" + extraEntries;
+		let cssText = "#output {" + outputAttributes + "} #commandinput {" + outputAttributes + "}" + extraEntries;
 		console.log("Skotos styling:", cssText);
 		// Set the SkotOS-theme CSS
 		cssMods.skotosAttributes = setStyle(cssText, cssMods.skotosAttributes);

--- a/orchil.js
+++ b/orchil.js
@@ -398,7 +398,7 @@ var c = {};
 				cat: "styling",
 				type: ["options"],
 				desc: "The colors and styles used for text.",
-				def: "light",
+				def: "skotos",
 				opt: {
 					light: "A light background wtih dark text.  The standard Skotos appearance.",
 					dark: "A dark background with light text.  Considered by many to be easier on the eyes.",
@@ -1626,7 +1626,8 @@ var c = {};
 		keepScrollPos();
 	}
 	function applySkotosTheme(attributes) {
-		var styleAttributes = "";
+		var outputAttributes = "";
+		var extraEntries = "";
 
 		console.log("applySkotosTheme", attributes);
 		console.log("Existing theme choice:", prefs.theme);
@@ -1646,16 +1647,27 @@ var c = {};
 		for(var i = 0; i < attrs.length; i++) {
 			if(attrs[i].substring(0, 8) == "bgcolor=") {
 				let bgColor = stripQuotes(attrs[i].substring(8));
-				styleAttributes += "background-color:" + bgColor + ";";
+				outputAttributes += "background-color:" + bgColor + ";";
 			} else if (attrs[i].substring(0,5) == "text=") {
 				let textColor = stripQuotes(attrs[i].substring(5));
-				styleAttributes += "color:" + textColor + ";";
+				outputAttributes += "color:" + textColor + ";";
+			} else if (attrs[i].substring(0,5) == "link=") {
+				let linkColor = stripQuotes(attrs[i].substring(5));
+				extraEntries += "\n#output a {color:" + linkColor + " !important}"
+			} else if (attrs[i].substring(0,6) == "vlink=") {
+				let linkColor = stripQuotes(attrs[i].substring(6));
+				extraEntries += "\n#output a:visited {color:" + linkColor + " !important} "
+			} else if (attrs[i].substring(0,6) == "alink=") {
+				let linkColor = stripQuotes(attrs[i].substring(6));
+				extraEntries += "\n#output a:active {color:" + linkColor + " !important}"
 			}
 			// Various unhandled attributes exist and we're ignoring them.
 		}
 
+		let cssText = "#output {" + outputAttributes + "}" + extraEntries;
+		console.log("Skotos styling:", cssText);
 		// Set the SkotOS-theme CSS
-		cssMods.skotosAttributes = setStyle("#output {" + styleAttributes + "}", cssMods.skotosAttributes);
+		cssMods.skotosAttributes = setStyle(cssText, cssMods.skotosAttributes);
 	}
 	function applyXchPage(attributes) {
 		if (attributes==="clear=\"text\"" || attributes==="clear=\"text\" /") {

--- a/theme-skotos.css
+++ b/theme-skotos.css
@@ -1,0 +1,19 @@
+#debugtoolbar      {color:#c7c7c7; background-color:#060b0e;}
+#commandinput      {color:#c7c7c7; background-color:#060b0e; border-color:black;}
+#output .error     {color:#990000; font-weight:100;}
+#output .gengrey   {color:#646464;}
+#output .genwhite  {color:#060b0e;}
+#output .genred    {color:#e12000;}
+#output .gengreen  {color:#00cd20;}
+#output .genorange {color:#ff9b00;}
+#output .genblue   {color:#3C5CFF;}
+#output .genpink   {color:#e119e1; text-shadow: #f0f 1px 0 10px;}
+#output .gencyan   {color:#00cde1;}
+#output .genblack  {color:#ffffff;}
+#output tbody tr:nth-child(odd) { background-color: #222;}
+#output tbody tr:nth-child(even) { background-color: #111;}
+#output thead tr:nth-child(even) { background-color: #333;}
+#output thead tr:nth-child(odd) { background-color: #2a2a2a;}
+#output .columnized > *:nth-child(odd) { color: #ffffff;}
+
+#output            {color:#c7c7c7; background-color:#060b0e; border-color:black;}


### PR DESCRIPTION
Add the ability to use server-side SkotOS colour themes with background and text colours

I'm not currently using some information that's sent through like link, vlink and alink colours. Hope to talk to the Marrach folks about exactly what that should affect. This is a massive improvement, though.

This should fix, either partially or wholly, issue https://github.com/ChatTheatre/orchil/issues/19
